### PR TITLE
gitigoner add env files

### DIFF
--- a/AMS/.gitignore
+++ b/AMS/.gitignore
@@ -22,3 +22,13 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment files
+.env
+.env.local
+.env.*.local
+.env.development
+.env.production
+
+# Keep example file
+!.env.example


### PR DESCRIPTION
This pull request includes a small change to the `.gitignore` file in the `AMS` directory. The change adds environment files to the ignore list while ensuring the example file is kept.

* [`AMS/.gitignore`](diffhunk://#diff-ad2824e5a261e5aa92d58903e202f5ad8187c8a5138a991daff7ba948d0b9079R25-R34): Added environment files to the ignore list and ensured that the example file is not ignored.